### PR TITLE
Improve the dataset and team tables

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -59,34 +59,34 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
   <div class="container d-flex justify-content-between">
-  <a class="navbar-brand" href="#">
-      {% unless logo_path == empty %}
-          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
-      {% endunless %}
-  </a>
+        <a class="navbar-brand" href="#">
+            {% unless logo_path == empty %}
+                <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
+            {% endunless %}
+        </a>
 
-  <div class="collapse navbar-collapse">
-    <ul class="navbar-nav ml-auto">
-        {%- for link in site.data.navigation.main -%}
-            {% if link.sublinks %}
-                <li class="nav-item dropdown collapse navbar-collapse">
-                    <a class="nav-link dropdown-toggle" id="navbarDropdown-{{ link.title }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        {{ link.title }}
-                    </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown-{{ link.title }}">
-                        <a class="dropdown-item" href="{{ site.baseurl }}{{ link.url }}">Overview</a>
-                        {% for sublink in link.sublinks %}
-                            <a class="dropdown-item" href="{{ site.baseurl }}{{ sublink.url }}">{{ sublink.title }}</a>
-                        {% endfor %}
-                    </div>
-                </li>
-            {% else %}
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ site.baseurl }}{{ link.url }}">{{ link.title }}</a>
-                </li>
-            {% endif %}
-        {% endfor %}
-    </ul>
-  </div>
-</div>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav ml-auto">
+                {%- for link in site.data.navigation.main -%}
+                    {% if link.sublinks %}
+                        <li class="nav-item dropdown collapse navbar-collapse">
+                            <a class="nav-link dropdown-toggle" id="navbarDropdown-{{ link.title }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                {{ link.title }}
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdown-{{ link.title }}">
+                                <a class="dropdown-item" href="{{ site.baseurl }}{{ link.url }}">Overview</a>
+                                {% for sublink in link.sublinks %}
+                                    <a class="dropdown-item" href="{{ site.baseurl }}{{ sublink.url }}">{{ sublink.title }}</a>
+                                {% endfor %}
+                            </div>
+                        </li>
+                    {% else %}
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ site.baseurl }}{{ link.url }}">{{ link.title }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
 </nav>

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -155,7 +155,8 @@ $max-width: $x-large !default;
    ========================================================================== */
 
 $right-sidebar-width-narrow: 100px !default;
-$right-sidebar-width: 200px !default;
+/* modified from 200px by TS to better match the width of the navbar/masthead */
+$right-sidebar-width: 100px !default;
 $right-sidebar-width-wide: 100px !default;
 
 /*

--- a/docs/datasets/_posts/2022-01-01-FAKE.md
+++ b/docs/datasets/_posts/2022-01-01-FAKE.md
@@ -1,0 +1,15 @@
+---
+title: "FAKE Dataset"
+excerpt: "FAKE"
+layout: single
+
+# Information for sidebar
+website:
+site:
+pi:
+sample_size:
+fmri_count:
+smri_count:
+---
+
+This is a fake dataset page included to test the page-building code.

--- a/docs/datasets/_posts/2023-01-01-BHRC.md
+++ b/docs/datasets/_posts/2023-01-01-BHRC.md
@@ -4,9 +4,12 @@ excerpt: "BHRC"
 layout: single
 
 # Information for sidebar
-pi: "Steve Buscemi"
 website: https://osf.io/ktz5h/
-neuroimaging: ["fMRI", "DWI", "sMRI"]
+site: Sao Paulo, Brazil
+pi: Firstname Lastname
+sample_size: 100
+fmri_count: 100
+smri_count: 100
 ---
 
 ## [About the dataset](https://osf.io/ktz5h/):

--- a/docs/datasets/_posts/2023-01-01-HBN.md
+++ b/docs/datasets/_posts/2023-01-01-HBN.md
@@ -4,11 +4,12 @@ excerpt: "HBN"
 layout: single
 
 # Information for sidebar
-about: https://healthybrainnetwork.org/
-site: "University of Florida"
-pi: "Robert Loggia"
-sample_size: 500
-neuroimaging: ["fMRI", "sMRI"]
+website: https://healthybrainnetwork.org/
+site: Child Mind Institute
+pi: Firstname Lastname
+sample_size: 80
+fmri_count: 80
+smri_count: 80
 ---
 ## [About the dataset](https://healthybrainnetwork.org/):
 

--- a/docs/datasets/_posts/2023-01-01-HCP-D.md
+++ b/docs/datasets/_posts/2023-01-01-HCP-D.md
@@ -4,7 +4,12 @@ excerpt: "HCP-D"
 layout: single
 
 # Information for sidebar
-about: https://www.humanconnectome.org/study/hcp-lifespan-development
+website: https://www.humanconnectome.org/study/hcp-lifespan-development
+site: Washington University of St. Louis
+pi: Firstname Lastname
+sample_size: 70
+fmri_count: 70
+smri_count: 70
 ---
 ## [About the dataset](https://www.humanconnectome.org/study/hcp-lifespan-development):
 ### Potential standard fields to include:

--- a/docs/datasets/_posts/2023-01-01-NKI.md
+++ b/docs/datasets/_posts/2023-01-01-NKI.md
@@ -4,7 +4,12 @@ excerpt: "NKI Sample"
 layout: single
 
 # Information for sidebar
-about: http://fcon_1000.projects.nitrc.org/indi/enhanced/
+website: http://fcon_1000.projects.nitrc.org/indi/enhanced/
+site: Nathan Kline Institute
+pi: Firstname Lastname
+sample_size: 60
+fmri_count: 60
+smri_count: 60
 ---
 ## [About the dataset](http://fcon_1000.projects.nitrc.org/indi/enhanced/):
 

--- a/docs/datasets/_posts/2023-01-01-PACCT.md
+++ b/docs/datasets/_posts/2023-01-01-PACCT.md
@@ -4,7 +4,12 @@ excerpt: "PACCT"
 layout: single
 
 # Information for sidebar
-about: https://danlab.site.drupaldisttest.cc.columbia.edu/research/studies
+website: https://danlab.site.drupaldisttest.cc.columbia.edu/research/studies
+site: Columbia University
+pi: Firstname Lastname
+sample_size: 50
+fmri_count: 50
+smri_count: 50
 ---
 ## [About the dataset](https://danlab.site.drupaldisttest.cc.columbia.edu/research/studies):
 

--- a/docs/datasets/_posts/2023-01-01-PNC.md
+++ b/docs/datasets/_posts/2023-01-01-PNC.md
@@ -4,7 +4,12 @@ excerpt: "PNC"
 layout: single
 
 # Information for sidebar
-about: https://www.med.upenn.edu/bbl/philadelphianeurodevelopmentalcohort.html
+website: https://www.med.upenn.edu/bbl/philadelphianeurodevelopmentalcohort.html
+site: University of Pennsylvania
+pi: Firstname Lastname
+sample_size: 40
+fmri_count: 40
+smri_count: 40
 ---
 ## [About the dataset](https://www.med.upenn.edu/bbl/philadelphianeurodevelopmentalcohort.html):
 

--- a/docs/datasets/_posts/2023-01-01-dCCNP.md
+++ b/docs/datasets/_posts/2023-01-01-dCCNP.md
@@ -4,8 +4,12 @@ excerpt: "dCCNP"
 layout: single
 
 # Information for sidebar
-about: https://www.sciencedirect.com/science/article/pii/S1878929321001109
-neuroimaging: ["qMRI"]
+website: https://www.sciencedirect.com/science/article/pii/S1878929321001109
+site: China
+pi: Firstname Lastname
+sample_size: 90
+fmri_count: 90
+smri_count: 90
 ---
 ## [About the dataset](https://www.sciencedirect.com/science/article/pii/S1878929321001109):
 ### Potential standard fields to include:

--- a/docs/datasets/index.html
+++ b/docs/datasets/index.html
@@ -27,17 +27,6 @@ Common data fields for each dataset {largely similar to ABIDE II/ADHD200}
 
 <hr/>
 
-{% assign neuroimaging_values = "" | split: "" %}
-
-{% for dataset in site.categories.datasets %}
-  {% for neuroimaging in dataset.neuroimaging %}
-    {% assign neuroimaging_values = neuroimaging_values | push: neuroimaging %}
-  {% endfor %}
-{% endfor %}
-
-{% assign unique_neuroimaging_values = neuroimaging_values | uniq %}
-{% assign unique_neuroimaging_values = unique_neuroimaging_values | sort %}
-
 <table align="center"; width=1250px>
   <thead>
     <tr>
@@ -46,28 +35,56 @@ Common data fields for each dataset {largely similar to ABIDE II/ADHD200}
       <th>Site</th>
       <th>PI</th>
       <th>Sample Size</th>
-      {% for unique_value in unique_neuroimaging_values %}
-        <th>{{ unique_value }}</th>
-      {% endfor %}
+      <th>Structural MRI</th>
+      <th>Functional MRI</th>
     </tr>
   </thead>
   <tbody>
     {% for dataset in site.categories.datasets %}
       <tr>
         <td><a href="{{ dataset.url }}">{{ dataset.title }}</a></td>
-        <td><a href="{{ dataset.website }}">link</a></td>
-        <td>{{ dataset.site }}</td>
-        <td>{{ dataset.pi }}</td>
-        <td>{{ dataset.sample_size }}</td>
-        {% for unique_value in unique_neuroimaging_values %}
-          <td>
-            {% if dataset.neuroimaging contains unique_value %}
-              <span style="color: green;">✓</span>
-            {% else %}
-            <span style="color: red;">X</span>
-            {% endif %}
-          </td>
-        {% endfor %}
+        <td>
+          {% if dataset.website %}
+            <a href="{{ dataset.website }}">link</a>
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
+        <td>
+          {% if dataset.site %}
+            {{ dataset.site }}
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
+        <td>
+          {% if dataset.pi %}
+            {{ dataset.pi }}
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
+        <td>
+          {% if dataset.sample_size %}
+            {{ dataset.sample_size }}
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
+        <td>
+          {% if dataset.smri_count %}
+            {{ dataset.smri_count }}
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
+        <td>
+          {% if dataset.fmri_count %}
+            {{ dataset.fmri_count }}
+          {% else %}
+            n/a
+          {% endif %}
+        </td>
       </tr>
     {% endfor %}
   </tbody>

--- a/docs/get_data.md
+++ b/docs/get_data.md
@@ -10,4 +10,6 @@ permalink: /docs/get_data
 ### Information about how to get data
 - For each study
 - ways to get data, github branches, sample filtering
-- Video from Matt about using datalad?
+- Video of Matt Cieslak walking through Datalad.
+
+<iframe width="400" height="200" src="https://www.youtube.com/embed/dRsBIffE_Xs?si=wNSO1f-EMQH8BmC7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/team/index.html
+++ b/docs/team/index.html
@@ -1,12 +1,12 @@
 ---
 layout: archive
-title: Contributors
+title: Team RBC
 ---
 {% assign team = site.categories.team | reverse %}
 
 <br>
 
-<table>
+<table style="display: flex; justify-content: center;">
 	{% tablerow member in team cols:2 %}
 		{% if member.image %}
 			{% assign image = member.image %}
@@ -17,7 +17,7 @@ title: Contributors
 			<a class="pull-left" href="{{ member.url }}" style="margin-right: 20px;">
 				<img src="{{ image }}" style="border-radius: 50%; width: 13vw; height: 13vw;">
 			</a>
-			<div class="media-body">
+			<div class="media-body" style="word-wrap: break-word; overflow-wrap: break-word;">
 				<p style="margin: 0px;">
 					{% if member.site %}
 						<a href="{{ member.site }}" class="off">{{ member.name }}</a>


### PR DESCRIPTION
- Fix the spacing in `_includes/masthead.html` (no content changes)
- Change `$right-sidebar-width` variable from 200px to 100px to better match the navigation bar/masthead's width. This is kind of a hacky solution and I'd prefer to directly match the widths at some point.
- Replace `neuroimaging` field in dataset headers with `smri_count` and `fmri_count`. Update the summary table on the datasets page to match.
- Rename "Contributors" page to "Team RBC".
- Modify the table on "Team RBC" so that (1) it's centered on the page and (2) text in cells wraps instead of adding a horizontal scroll bar.