### PR TITLE
Move local stylesheet after Bootstrap stylesheet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,8 +14,8 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="stylesheet" href="/assets/css/custom.css">
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css">


### PR DESCRIPTION
Heading font size was determined by the Bootstrap stylesheet, so I switched to loading the minimal mistakes stylesheet _after_ the Bootstrap one so we can modify the settings in the repo's SASS/CSS files as we wish.