### PR TITLE
Update docs for fMRIPrep and XCP-D release

### DIFF
--- a/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
+++ b/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
@@ -12,4 +12,3 @@ For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data pag
 Run into issues?
 Click the "Get Support" link in the footer and reach out to us on NeuroStars; be sure to use the `rbc` tag to make sure we find it.
 We genuinely welcome your feedback and will strive to make RBC as user-friendly as possible moving forward.
-In this `News` section we will highlight updates to and uses of RBC – so please just reach out to Ted (sattertt at upenn dot edu) directly if you want us to highlight your work using RBC here.

--- a/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
+++ b/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
@@ -1,0 +1,15 @@
+---
+title: "fMRIPrep and XCP-D Derivatives Release"
+author: "RBC Team"
+layout: blogpost
+---
+
+We are pleased to announce a new RBC release with fMRIPrep and XCP-D derivatives.
+This release adds the following derivatives: sMRIPrep, FreeSurfer-Post tabular derivatives, fMRIPrep, and XCP-D outputs.
+
+For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release). For more information on processing pipelines, see [Image Processing](/docs/imaging/image_processing/).
+
+Run into issues?
+Click the "Get Support" link in the footer and reach out to us on NeuroStars; be sure to use the `rbc` tag to make sure we find it.
+We genuinely welcome your feedback and will strive to make RBC as user-friendly as possible moving forward.
+In this `News` section we will highlight updates to and uses of RBC – so please just reach out to Ted (sattertt at upenn dot edu) directly if you want us to highlight your work using RBC here.

--- a/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
+++ b/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
@@ -7,7 +7,7 @@ layout: blogpost
 We are pleased to announce a new RBC release with fMRIPrep and XCP-D derivatives.
 This release adds the following derivatives: sMRIPrep, FreeSurfer-Post tabular derivatives, fMRIPrep, and XCP-D outputs.
 
-For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}). For more information on processing pipelines, see [Image Processing]({{ "/docs/imaging/image_processing/" | relative_url }}).
+For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}). For more information on processing pipelines, see [Image Processing]({{ "/docs/imaging/image_processing/#07062026-new-fmriprep-and-xcp-d-derivative-release" | relative_url }}).
 
 Run into issues?
 Click the "Get Support" link in the footer and reach out to us on NeuroStars; be sure to use the `rbc` tag to make sure we find it.

--- a/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
+++ b/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
@@ -7,7 +7,7 @@ layout: blogpost
 We are pleased to announce a new RBC release with fMRIPrep and XCP-D derivatives.
 This release adds the following derivatives: sMRIPrep, FreeSurfer-Post tabular derivatives, fMRIPrep, and XCP-D outputs.
 
-For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}). For more information on processing pipelines, see [Image Processing]({{ "/docs/imaging/image_processing/#07062026-new-fmriprep-and-xcp-d-derivative-release" | relative_url }}).
+For access, see the [fMRIPrep and XCP-D Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}). For more information on processing pipelines, see [Image Processing]({{ "/docs/imaging/image_processing/#07062026-fmriprep-and-xcp-d-release" | relative_url }}).
 
 Run into issues?
 Click the "Get Support" link in the footer and reach out to us on NeuroStars; be sure to use the `rbc` tag to make sure we find it.

--- a/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
+++ b/docs/blog/_posts/2026-07-06-fmriprep-xcpd-release.md
@@ -7,7 +7,7 @@ layout: blogpost
 We are pleased to announce a new RBC release with fMRIPrep and XCP-D derivatives.
 This release adds the following derivatives: sMRIPrep, FreeSurfer-Post tabular derivatives, fMRIPrep, and XCP-D outputs.
 
-For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release). For more information on processing pipelines, see [Image Processing](/docs/imaging/image_processing/).
+For access, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}). For more information on processing pipelines, see [Image Processing]({{ "/docs/imaging/image_processing/" | relative_url }}).
 
 Run into issues?
 Click the "Get Support" link in the footer and reach out to us on NeuroStars; be sure to use the `rbc` tag to make sure we find it.

--- a/docs/get_data.md
+++ b/docs/get_data.md
@@ -33,6 +33,31 @@ The repositories (you can find them all
 
 where `<study>` is replaced with `HBN`, `NKI`, `PNC`, `BHRC` or `CCNP`.
 
+<details class="notice--primary" markdown="1">
+<summary><b>Download data</b></summary>
+<br>
+
+Clone the repository, then use `datalad get` to retrieve file contents:
+
+```bash
+# Clone with HTTPS
+datalad clone https://github.com/ReproBrainChart/<study>_<pipeline>.git
+
+# Or clone with SSH
+datalad clone git@github.com:ReproBrainChart/<study>_<pipeline>.git
+
+# Example: clone the HBN XCP-D repository
+datalad clone https://github.com/ReproBrainChart/HBN_XCP-D.git
+
+# Then enter the repository
+cd HBN_XCP-D
+
+# Download specific files
+datalad get sub-*/ses-*/func/*fsLR_den-91k_desc-denoised_bold.dtseries.nii
+```
+
+</details>
+
 **Boilerplate** detailing processing steps is available in each repository at `logs/CITATION.md`.
 
 <details markdown="1">

--- a/docs/get_data.md
+++ b/docs/get_data.md
@@ -17,7 +17,7 @@ permalink: /docs/get_data
 
 <a id="fmriprep-xcpd-pipeline-release"></a>
 <details class="notice--warning notice--lg" markdown="1">
-<summary><b>07/06/2026: fMRIPrep/XCP-D Pipeline Release</b></summary>
+<summary><b>07/06/2026: fMRIPrep and XCP-D Release</b></summary>
 <br>
 
 You can find the FreeSurfer, fMRIPrep and XCP-D derivatives in their corresponding

--- a/docs/get_data.md
+++ b/docs/get_data.md
@@ -15,6 +15,114 @@ permalink: /docs/get_data
   Please see [this link](https://gjaxx.r.a.d.sendibm1.com/mk/mr/sh/WCPxRrNLV1LtxMyPT3y1oQhxaYvOr2Of/SZQ42E1kj4hy) for a full description of this issue and our response.
 </div>
 
+<a id="fmriprep-xcpd-pipeline-release"></a>
+<details class="notice--warning notice--lg" markdown="1">
+<summary><b>07/06/2026: fMRIPrep/XCP-D Pipeline Release</b></summary>
+<br>
+
+You can find the FreeSurfer, fMRIPrep and XCP-D derivatives in their corresponding
+repositories on GitHub.
+
+The repositories (you can find them all
+[here](https://github.com/orgs/ReproBrainChart/repositories)) are named as followed:
+
+ * If you're looking for **fMRIPrep anatomical** (processed with `--anat-only`) and **FreeSurfer** derivatives, the repo will be named `<study>_fMRIPrep-Anat`
+ * If you're looking for **fMRIPrep functional** derivatives, the repo will be named `<study>_fMRIPrep-Func`
+ * If you're looking for [**FreeSurfer-Post**](https://github.com/PennLINC/freesurfer-post) derivatives, the repo will be named `<study>_FreeSurfer-Post`
+ * If you're looking for [**XCP-D**](https://xcp-d.readthedocs.io/en/latest/) derivatives, the repo will be named `<study>_XCP-D`
+
+where `<study>` is replaced with `HBN`, `NKI`, `PNC`, `BHRC` or `CCNP`.
+
+**Boilerplate** detailing processing steps is available in each repository at `logs/CITATION.md`.
+
+<details markdown="1">
+<summary><b>fMRIPrep anat only</b> command</summary>
+
+```bash
+singularity run --cleanenv \
+    -B "${PWD}" \
+    -B "code/license.txt:/SGLR/FREESURFER_HOME/license.txt" \
+    containers/.datalad/environments/fmriprep-<version>/image \
+    inputs/data/BIDS \
+    outputs/fmriprep_anat \
+    participant \
+    -w "${PWD}/.git/tmp/wkdir" \
+    --stop-on-first-crash \
+    --fs-license-file /SGLR/FREESURFER_HOME/license.txt \
+    --output-spaces MNI152NLin6Asym:res-1 \
+    --force-bbr \
+    --skip-bids-validation \
+    -vv \
+    --anat-only \
+    --cifti-output 91k \
+    --n_cpus 9 \
+    --mem-mb 14000 \
+    --bids-filter-file "${session-filterfile}" \
+    --participant-label "${subid}"
+```
+</details>
+
+<details markdown="1">
+<summary><b>fMRIPrep func</b> command</summary>
+
+```bash
+singularity run --cleanenv \
+    -B "${PWD}" \
+    -B "code/license.txt:/SGLR/FREESURFER_HOME/license.txt" \
+    containers/.datalad/environments/fmriprep-<version>/image \
+    inputs/data/BIDS \
+    outputs/fmriprep_func \
+    participant \
+    -w "${PWD}/.git/tmp/wkdir" \
+    --stop-on-first-crash \
+    --fs-license-file /SGLR/FREESURFER_HOME/license.txt \
+    --output-spaces func T1w MNI152NLin6Asym:res-2 \
+    --force-bbr \
+    --skip-bids-validation \
+    -vv \
+    --cifti-output 91k \
+    --n_cpus 4 \
+    --mem-mb 30000 \
+    --fs-subjects-dir inputs/data/fmriprep_anat/fmriprep_anat/sourcedata/freesurfer \
+    --bids-filter-file "${session-filterfile}" \
+    --participant-label "${subid}"
+```
+</details>
+
+<details markdown="1">
+<summary><b>XCP-D</b> command</summary>
+
+```bash
+singularity run --cleanenv \
+    -B ${PWD} \
+    -B code/license.txt:/SGLR/FREESURFER_HOME/license.txt \
+    containers/.datalad/environments/xcpd-0-10-6/image \
+    inputs/data/fmriprep_func/fmriprep_func \
+    outputs/xcpd \
+    participant \
+    -w ${PWD}/.git/tmp/wkdir \
+    --stop-on-first-crash \
+    --fs-license-file /SGLR/FREESURFER_HOME/license.txt \
+    -vv \
+    --mode linc \
+    --dummy-scans auto \
+    --input-type fmriprep \
+    --nthreads 8 \
+    --omp-nthreads 8 \
+    --mem-gb 50 \
+    --atlases 4S1056Parcels 4S156Parcels 4S256Parcels 4S356Parcels 4S456Parcels 4S556Parcels 4S656Parcels 4S756Parcels 4S856Parcels 4S956Parcels Glasser Gordon HCP MIDB Tian \
+    --participant-label "${subid#sub-}"
+```
+</details>
+
+<br>
+
+The following **QC files** are available in each repository:
+
+ * `study-<study>_desc-T1_qc.tsv`
+ * `study-<study>_desc-func_qc.tsv`
+</details>
+
 ### Install DataLad
 
 RBC is accessible via `datalad`. Follow the instructions [here](https://www.datalad.org/#install)
@@ -160,4 +268,3 @@ of data you plan on copying to your computer:
 at most a few free GB.
  * If you plan on copying 3D imaging data (e.g. ALFF, REHO) you will need hundreds of GB free.
  * If you plan on copying 4D denoised BOLD timeseries data you will need up to 4TB of free space.
-

--- a/docs/imaging/_posts/2020-01-01-image_processing.md
+++ b/docs/imaging/_posts/2020-01-01-image_processing.md
@@ -20,3 +20,22 @@ Derivatives are available in volumetric MNI space as well as in parcellated form
 A more detailed description of the list of outputs can be obtained [here](https://fcp-indi.github.io/docs/nightly/user/output_dir).
 
 A repository describing all of the atlases used by C-PAC in RBC can be found [here](https://github.com/FCP-INDI/C-PAC_templates/tree/d2913cd6d5861d9cb5ffb79aa03da18b6eb603eb/sourcedata/atlases).
+
+## 07/06/2026: New fMRIPrep and XCP-D Derivative Release
+
+RBC now also provides fMRIPrep and XCP-D derivatives.
+For repository naming, Singularity commands, boilerplate locations, QC files, and access instructions, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release).
+
+Structural MRI data were processed with [fMRIPrep](https://fmriprep.org/) using the `--anat-only` flag.
+T1w images were corrected for intensity non-uniformity with ANTs N4BiasFieldCorrection, skull-stripped with the ANTs brain extraction workflow using the OASIS30ANTs target template, and segmented into CSF, white matter, and gray matter with FSL FAST.
+Brain surfaces were reconstructed with FreeSurfer `recon-all`, and the brain mask was refined by reconciling ANTs-derived and FreeSurfer-derived cortical gray matter segmentations.
+T1w images were nonlinearly normalized to MNI152NLin6Asym and MNI152NLin2009cAsym templates accessed through TemplateFlow, and 91k-sample grayordinate files were resampled onto fsLR with Connectome Workbench.
+FreeSurfer outputs were further processed with [FreeSurfer-Post](https://github.com/PennLINC/freesurfer-post) to produce tabulated structural data.
+
+Functional MRI data were preprocessed with [fMRIPrep](https://fmriprep.org/).
+For each BOLD run, fMRIPrep generated a BOLD reference, estimated head-motion parameters with FSL MCFLIRT, and co-registered the BOLD reference to the T1w reference with FreeSurfer `bbregister` boundary-based registration.
+Confound time series include framewise displacement (FD), DVARS, global CSF, white matter, and whole-brain signals, CompCor physiological regressors, motion estimates, temporal derivatives, and quadratic terms.
+Frames exceeding 0.5 mm FD or 1.5 standardized DVARS were annotated as motion outliers. Grayordinates files containing 91k samples were also generated with surface data transformed directly to fsLR space and subcortical data transformed to 2 mm resolution MNI152NLin6Asym space. All resamplings can be performed with a single interpolation step by composing all the pertinent transformations (i.e. head-motion transform matrices, susceptibility distortion correction when available, and co-registrations to anatomical and output spaces). Gridded (volumetric) resamplings were performed using nitransforms, configured with cubic B-spline interpolation.
+
+Post-processing of fMRIPrep outputs was performed with [XCP-D](https://xcp-d.readthedocs.io/en/latest/) using the `--mode linc` flag.
+XCP-D discarded non-steady-state volumes, selected 36 nuisance regressors using the 36P strategy, despiked BOLD data with AFNI 3dDespike, band-pass filtered the data to retain 0.01–0.08 Hz signals, and smoothed denoised BOLD data with a 6 mm FWHM Gaussian kernel. Atlases used in the workflow included the Schaefer 4S atlas at 10 resolutions, Glasser, Gordon, Tian, HCP, and MIDB atlases. XCP-D produced processed functional timeseries, pairwise functional connectivity, ALFF, and ReHo, with surface ReHo computed using 2dReHo and subcortical ReHo computed using AFNI `3dReHo`.

--- a/docs/imaging/_posts/2020-01-01-image_processing.md
+++ b/docs/imaging/_posts/2020-01-01-image_processing.md
@@ -24,7 +24,7 @@ A repository describing all of the atlases used by C-PAC in RBC can be found [he
 ## 07/06/2026: New fMRIPrep and XCP-D Derivative Release
 
 RBC now also provides fMRIPrep and XCP-D derivatives.
-For repository naming, Singularity commands, boilerplate locations, QC files, and access instructions, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release).
+For more information, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release).
 
 Structural MRI data were processed with [fMRIPrep](https://fmriprep.org/) using the `--anat-only` flag.
 T1w images were corrected for intensity non-uniformity with ANTs N4BiasFieldCorrection, skull-stripped with the ANTs brain extraction workflow using the OASIS30ANTs target template, and segmented into CSF, white matter, and gray matter with FSL FAST.

--- a/docs/imaging/_posts/2020-01-01-image_processing.md
+++ b/docs/imaging/_posts/2020-01-01-image_processing.md
@@ -21,21 +21,21 @@ A more detailed description of the list of outputs can be obtained [here](https:
 
 A repository describing all of the atlases used by C-PAC in RBC can be found [here](https://github.com/FCP-INDI/C-PAC_templates/tree/d2913cd6d5861d9cb5ffb79aa03da18b6eb603eb/sourcedata/atlases).
 
-## 07/06/2026: New fMRIPrep and XCP-D Derivative Release
+## 07/06/2026: fMRIPrep and XCP-D Release
 
-RBC now also provides fMRIPrep and XCP-D derivatives.
-For more information, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}).
+RBC now also provides fMRIPrep, FreeSurfer, and XCP-D derivatives.
+For more information, see the [fMRIPrep and XCP-D Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}).
 
 Structural MRI data were processed with [fMRIPrep](https://fmriprep.org/) using the `--anat-only` flag.
-T1w images were corrected for intensity non-uniformity with ANTs N4BiasFieldCorrection, skull-stripped with the ANTs brain extraction workflow using the OASIS30ANTs target template, and segmented into CSF, white matter, and gray matter with FSL FAST.
+T1w images were corrected for intensity non-uniformity with ANTs `N4BiasFieldCorrection`, skull-stripped with the ANTs brain extraction workflow using the OASIS30ANTs as target template, and segmented into CSF, white matter, and gray matter with FSL `FAST`.
 Brain surfaces were reconstructed with FreeSurfer `recon-all`, and the brain mask was refined by reconciling ANTs-derived and FreeSurfer-derived cortical gray matter segmentations.
-T1w images were nonlinearly normalized to MNI152NLin6Asym and MNI152NLin2009cAsym templates accessed through TemplateFlow, and 91k-sample grayordinate files were resampled onto fsLR with Connectome Workbench.
+T1w images were nonlinearly normalized to MNI152NLin6Asym and MNI152NLin2009cAsym templates accessed through `TemplateFlow`. Grayordinate "dscalar" files containing 91k samples were resampled onto fsLR using the Connectome Workbench. Finally, 
 FreeSurfer outputs were further processed with [FreeSurfer-Post](https://github.com/PennLINC/freesurfer-post) to produce tabulated structural data.
 
 Functional MRI data were preprocessed with [fMRIPrep](https://fmriprep.org/).
-For each BOLD run, fMRIPrep generated a BOLD reference, estimated head-motion parameters with FSL MCFLIRT, and co-registered the BOLD reference to the T1w reference with FreeSurfer `bbregister` boundary-based registration.
+For each BOLD run, fMRIPrep generated a BOLD reference, estimated head-motion parameters with FSL `MCFLIRT`, and co-registered the BOLD reference to the T1w reference with FreeSurfer `bbregister` boundary-based registration.
 Confound time series include framewise displacement (FD), DVARS, global CSF, white matter, and whole-brain signals, CompCor physiological regressors, motion estimates, temporal derivatives, and quadratic terms.
 Frames exceeding 0.5 mm FD or 1.5 standardized DVARS were annotated as motion outliers. Grayordinates files containing 91k samples were also generated with surface data transformed directly to fsLR space and subcortical data transformed to 2 mm resolution MNI152NLin6Asym space. All resamplings can be performed with a single interpolation step by composing all the pertinent transformations (i.e. head-motion transform matrices, susceptibility distortion correction when available, and co-registrations to anatomical and output spaces). Gridded (volumetric) resamplings were performed using nitransforms, configured with cubic B-spline interpolation.
 
 Post-processing of fMRIPrep outputs was performed with [XCP-D](https://xcp-d.readthedocs.io/en/latest/) using the `--mode linc` flag.
-XCP-D discarded non-steady-state volumes, selected 36 nuisance regressors using the 36P strategy, despiked BOLD data with AFNI 3dDespike, band-pass filtered the data to retain 0.01–0.08 Hz signals, and smoothed denoised BOLD data with a 6 mm FWHM Gaussian kernel. Atlases used in the workflow included the Schaefer 4S atlas at 10 resolutions, Glasser, Gordon, Tian, HCP, and MIDB atlases. XCP-D produced processed functional timeseries, pairwise functional connectivity, ALFF, and ReHo, with surface ReHo computed using 2dReHo and subcortical ReHo computed using AFNI `3dReHo`.
+XCP-D discarded non-steady-state volumes, selected 36 nuisance regressors, despiked BOLD data with AFNI `3dDespike`, band-pass filtered the data to retain 0.01–0.08 Hz signals, and smoothed denoised BOLD data with a 6 mm FWHM Gaussian kernel. Atlases used in the workflow included the Schaefer 4S atlas at 10 resolutions, Glasser, Gordon, Tian, HCP, and MIDB. XCP-D produced processed functional timeseries, pairwise functional connectivity, ALFF, and ReHo, with surface ReHo computed using `2dReHo` and subcortical ReHo computed using AFNI `3dReHo`.

--- a/docs/imaging/_posts/2020-01-01-image_processing.md
+++ b/docs/imaging/_posts/2020-01-01-image_processing.md
@@ -24,7 +24,7 @@ A repository describing all of the atlases used by C-PAC in RBC can be found [he
 ## 07/06/2026: New fMRIPrep and XCP-D Derivative Release
 
 RBC now also provides fMRIPrep and XCP-D derivatives.
-For more information, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page](/docs/get_data#fmriprep-xcpd-pipeline-release).
+For more information, see the [fMRIPrep/XCP-D Pipeline Release section on the Get Data page]({{ "/docs/get_data#fmriprep-xcpd-pipeline-release" | relative_url }}).
 
 Structural MRI data were processed with [fMRIPrep](https://fmriprep.org/) using the `--anat-only` flag.
 T1w images were corrected for intensity non-uniformity with ANTs N4BiasFieldCorrection, skull-stripped with the ANTs brain extraction workflow using the OASIS30ANTs target template, and segmented into CSF, white matter, and gray matter with FSL FAST.


### PR DESCRIPTION
Updates the Get Data, Image Processing, and News pages for the fMRIPrep/XCP-D derivative release.